### PR TITLE
Modernize bencode library and add CLI

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,0 +1,3 @@
+source "https://rubygems.org"
+
+gemspec

--- a/README
+++ b/README
@@ -1,5 +1,0 @@
-USAGE
-
-Bencode.encode(object)
-Bencode.decode(string)
-

--- a/README.md
+++ b/README.md
@@ -1,0 +1,59 @@
+# Bencode
+
+A modern, minimal Ruby implementation of the [bencode](https://en.wikipedia.org/wiki/Bencode) encoding format with a small command-line interface.
+
+## Installation
+
+```bash
+gem build bencode.gemspec
+# gem install ./bencode-0.1.0.gem
+```
+
+## Library usage
+
+```ruby
+require "bencode"
+
+payload = Bencode.encode({ "hello" => [1, "world"] })
+# => "d5:hellol1e5:worldee"
+
+object = Bencode.decode(payload)
+# => {"hello"=>[1, "world"]}
+```
+
+Encoding supports strings, symbols, integers, arrays, and hashes (with string or symbol keys). Dictionary keys are sorted to produce deterministic output. Decoding returns plain Ruby strings, integers, arrays, and hashes.
+
+## Command line
+
+The `bencode` executable can decode bencoded input to pretty-printed JSON or encode JSON into bencode. Input defaults to STDIN and output defaults to STDOUT.
+
+```bash
+# Decode a torrent file to JSON
+bencode --decode --file ./example.torrent
+
+# Encode JSON to bencode, writing the output to a file
+cat payload.json | bencode --encode --output payload.bencode
+```
+
+Options:
+
+- `-e`, `--encode` – encode JSON input into bencode
+- `-d`, `--decode` – decode bencode input into JSON (default)
+- `-f`, `--file FILE` – read input from a file instead of STDIN
+- `-o`, `--output FILE` – write output to a file instead of STDOUT
+- `-h`, `--help` – show usage information
+
+## Development
+
+Run the test suite with:
+
+```bash
+bundle install
+bundle exec rspec
+```
+
+Or using the default rake task:
+
+```bash
+bundle exec rake
+```

--- a/Rakefile
+++ b/Rakefile
@@ -1,0 +1,8 @@
+# frozen_string_literal: true
+
+require "bundler/gem_tasks"
+require "rspec/core/rake_task"
+
+RSpec::Core::RakeTask.new(:spec)
+
+task default: :spec

--- a/bencode.gemspec
+++ b/bencode.gemspec
@@ -1,0 +1,27 @@
+# frozen_string_literal: true
+
+require_relative "lib/bencode/version"
+
+Gem::Specification.new do |spec|
+  spec.name          = "bencode"
+  spec.version       = Bencode::VERSION
+  spec.authors       = ["Example Maintainer"]
+  spec.email         = ["maintainer@example.com"]
+
+  spec.summary       = "A small bencode encoder/decoder"
+  spec.description   = "Modern Ruby library and CLI for encoding and decoding bencoded data."
+  spec.homepage      = "https://example.com/bencode"
+  spec.license       = "MIT"
+
+  spec.files         = Dir["lib/**/*", "bin/*", "README.md", "LICENSE"]
+  spec.bindir        = "bin"
+  spec.executables   = ["bencode"]
+  spec.require_paths = ["lib"]
+
+  spec.metadata["homepage_uri"] = spec.homepage
+  spec.metadata["source_code_uri"] = "https://example.com/bencode"
+  spec.metadata["changelog_uri"] = "https://example.com/bencode/changelog"
+
+  spec.add_development_dependency "bundler", "~> 2.0"
+  spec.add_development_dependency "rspec", "~> 3.0"
+end

--- a/bin/bencode
+++ b/bin/bencode
@@ -1,0 +1,49 @@
+#!/usr/bin/env ruby
+# frozen_string_literal: true
+
+require "optparse"
+require "json"
+require "bencode"
+
+options = {
+  mode: :decode,
+  input_path: nil,
+  output_path: nil
+}
+
+parser = OptionParser.new do |opts|
+  opts.banner = "Usage: bencode [options]\n\nExamples:\n  bencode --decode --file input.torrent\n  bencode --encode < data.json\n  bencode --encode --output payload.bencode < data.json"
+
+  opts.on("-e", "--encode", "Encode JSON from STDIN or --file to bencode") { options[:mode] = :encode }
+  opts.on("-d", "--decode", "Decode bencode from STDIN or --file to JSON") { options[:mode] = :decode }
+  opts.on("-f", "--file FILE", "Read input from file instead of STDIN") { |file| options[:input_path] = file }
+  opts.on("-o", "--output FILE", "Write output to file instead of STDOUT") { |file| options[:output_path] = file }
+  opts.on("-h", "--help", "Show help") do
+    puts opts
+    exit
+  end
+end
+
+parser.parse!
+
+input_io = options[:input_path] ? File.open(options[:input_path], "r") : $stdin
+output_io = options[:output_path] ? File.open(options[:output_path], "w") : $stdout
+
+begin
+  payload = input_io.read
+
+  result = case options[:mode]
+           when :decode
+             JSON.pretty_generate(Bencode.decode(payload))
+           when :encode
+             Bencode.encode(JSON.parse(payload))
+           else
+             raise Bencode::Error, "Unknown mode: #{options[:mode]}"
+           end
+
+  output_io.write(result)
+  output_io.write("\n") if options[:mode] == :decode && output_io == $stdout
+ensure
+  input_io.close if options[:input_path]
+  output_io.close if options[:output_path]
+end

--- a/lib/bencode.rb
+++ b/lib/bencode.rb
@@ -2,111 +2,20 @@
 
 module Bencode
   class Error < StandardError; end
-
-  class Scanner < String
-    TOKENS = { 'd' => 1, 'l' => 2, 'i' => 3, ':' => 4, 'e' => 5 }.freeze
-    STATES = {
-      0 => [4, 1, 2, 3, 4, -1], # parse started
-      1 => [],                  # dictionary started
-      2 => [],                  # list started
-      3 => [6, -1, -1, -1, -1, 0], # integer started
-      4 => [4, -1, -1, -1, 0, -1], # string length started
-      6 => [6, -1, -1, -1, -1, 0]  # integer body
-    }.freeze
-
-    def initialize(str)
-      @pos = -1
-      super(str)
-    end
-
-    def scan
-      @pos += 1
-      current = 0
-      buffer = +''
-      while @pos < size
-        ch = self[@pos]
-        token = ch =~ /\d/ ? 0 : TOKENS[ch]
-        state = STATES[current][token]
-        case state
-        when -1
-          return nil
-        when 0
-          case current
-          when 3
-            return 0
-          when 6
-            return buffer.to_i
-          when 4
-            len = buffer.to_i
-            str = self[@pos + 1, len]
-            @pos += len
-            return str
-          end
-        when 1
-          dict = {}
-          while (obj = scan)
-            dict[obj] = scan
-          end
-          return dict
-        when 2
-          list = []
-          while (obj = scan)
-            list << obj
-          end
-          return list
-        end
-
-        buffer = state != current ? ch : buffer + ch
-        current = state
-        @pos += 1
-      end
-    end
-  end
-
-  class << self
-    def encode(object)
-      object.bencode
-    end
-
-    def decode(str)
-      Scanner.new(str).scan
-    end
-  end
 end
 
-class Object
-  def bencode
-    raise Bencode::Error, "can't bencode #{self.class}"
+require_relative "bencode/version"
+require_relative "bencode/encoder"
+require_relative "bencode/decoder"
+
+module Bencode
+  module_function
+
+  def encode(object)
+    Encoder.new.encode(object)
+  end
+
+  def decode(payload)
+    Decoder.new(payload).decode
   end
 end
-
-class String
-  def bencode
-    "#{size}:#{self}"
-  end
-end
-
-class Integer
-  def bencode
-    "i#{self}e"
-  end
-end
-
-class Array
-  def bencode
-    "l#{map(&:bencode).join}e"
-  end
-end
-
-class Symbol
-  def bencode
-    to_s.bencode
-  end
-end
-
-class Hash
-  def bencode
-    "d#{map { |k, v| [k.bencode, v.bencode] }.flatten.join}e"
-  end
-end
-

--- a/lib/bencode/decoder.rb
+++ b/lib/bencode/decoder.rb
@@ -1,0 +1,102 @@
+# frozen_string_literal: true
+
+module Bencode
+  class DecodeError < Error; end
+
+  class Decoder
+    def initialize(payload)
+      @payload = payload
+      @index = 0
+    end
+
+    def decode
+      result = read_value
+      ensure_consumed!
+      result
+    end
+
+    private
+
+    attr_reader :payload
+
+    def ensure_consumed!
+      raise DecodeError, "Unexpected trailing data" if @index < payload.length
+    end
+
+    def read_value
+      raise DecodeError, "Unexpected end of input" if @index >= payload.length
+
+      case payload[@index]
+      when 'i'
+        read_integer
+      when 'l'
+        read_list
+      when 'd'
+        read_dictionary
+      when /\d/
+        read_string
+      else
+        raise DecodeError, "Unknown token: #{payload[@index].inspect}"
+      end
+    end
+
+    def read_integer
+      @index += 1
+      terminator_index = payload.index('e', @index)
+      raise DecodeError, "Unterminated integer" unless terminator_index
+
+      number = payload[@index...terminator_index]
+      raise DecodeError, "Invalid integer" unless number.match?(/^-?\d+$/)
+
+      @index = terminator_index + 1
+      number.to_i
+    end
+
+    def read_string
+      length_end = payload.index(':', @index)
+      raise DecodeError, "Invalid string length" unless length_end
+
+      length = payload[@index...length_end].to_i
+      raise DecodeError, "Negative string length" if length.negative?
+
+      string_start = length_end + 1
+      string_end = string_start + length
+      raise DecodeError, "Unexpected end of string" if string_end > payload.length
+
+      value = payload[string_start...string_end]
+      @index = string_end
+      value
+    end
+
+    def read_list
+      @index += 1
+      items = []
+      until payload[@index] == 'e'
+        raise DecodeError, "Unterminated list" if @index >= payload.length
+
+        items << read_value
+      end
+
+      @index += 1
+      items
+    end
+
+    def read_dictionary
+      @index += 1
+      dictionary = {}
+      until payload[@index] == 'e'
+        raise DecodeError, "Unterminated dictionary" if @index >= payload.length
+
+        key = read_value
+        unless key.is_a?(String)
+          raise DecodeError, "Dictionary keys must be strings, got: #{key.class}"
+        end
+
+        dictionary[key] = read_value
+      end
+
+      @index += 1
+      dictionary
+    end
+  end
+end

--- a/lib/bencode/encoder.rb
+++ b/lib/bencode/encoder.rb
@@ -1,0 +1,51 @@
+# frozen_string_literal: true
+
+module Bencode
+  class EncodeError < Error; end
+
+  class Encoder
+    def encode(object)
+      case object
+      when String
+        encode_string(object)
+      when Symbol
+        encode_string(object.to_s)
+      when Integer
+        "i#{object}e"
+      when Array
+        "l#{object.map { |element| encode(element) }.join}e"
+      when Hash
+        encode_hash(object)
+      else
+        raise EncodeError, "Unsupported type for bencode: #{object.class}"
+      end
+    end
+
+    private
+
+    def encode_string(value)
+      "#{value.bytesize}:#{value}"
+    end
+
+    def encode_hash(hash)
+      entries = hash.keys.sort_by { |key| key_to_string(key) }.map do |key|
+        encoded_key = encode_string(key_to_string(key))
+        encoded_value = encode(hash.fetch(key))
+        "#{encoded_key}#{encoded_value}"
+      end
+
+      "d#{entries.join}e"
+    end
+
+    def key_to_string(key)
+      case key
+      when String
+        key
+      when Symbol
+        key.to_s
+      else
+        raise EncodeError, "Dictionary keys must be strings or symbols, got: #{key.class}"
+      end
+    end
+  end
+end

--- a/lib/bencode/version.rb
+++ b/lib/bencode/version.rb
@@ -1,0 +1,5 @@
+# frozen_string_literal: true
+
+module Bencode
+  VERSION = "0.1.0"
+end

--- a/spec/bencode_spec.rb
+++ b/spec/bencode_spec.rb
@@ -1,72 +1,97 @@
-require 'spec_helper'
-require 'bencode'
+# frozen_string_literal: true
 
-describe Bencode do
-  it "should encode string" do
-    Bencode.encode("hello").should == '5:hello'
-    Bencode.encode("world").should == '5:world'
-    Bencode.encode("Hello,World!").should == '12:Hello,World!'
-    Bencode.encode(:symbol).should == '6:symbol'
-  end
+require "spec_helper"
+require "tempfile"
+require "json"
 
-  it "should encode integer" do
-    Bencode.encode(111).should == 'i111e'
-    Bencode.encode(2222).should == 'i2222e'
-  end
+RSpec.describe Bencode do
+  describe ".encode" do
+    it "encodes strings and symbols" do
+      expect(described_class.encode("hello")).to eq("5:hello")
+      expect(described_class.encode(:symbol)).to eq("6:symbol")
+    end
 
-  it "should encode list" do
-    Bencode.encode([1,2,3]).should == "li1ei2ei3ee"
-    Bencode.encode([1,'2','3']).should == "li1e1:21:3e"
-  end
+    it "encodes integers" do
+      expect(described_class.encode(2222)).to eq("i2222e")
+    end
 
-  it "should encode dictionary" do
-    Bencode.encode({'hello' => 'world'}).should == 'd5:hello5:worlde'
-  end
-end
+    it "encodes lists" do
+      expect(described_class.encode([1, "2", "3"])).to eq("li1e1:21:3e")
+    end
 
-describe Bencode do
-  it "should decode string" do
-    Bencode.decode("5:hello").should == 'hello'
-    Bencode.decode("0:").should == ''
-  end
+    it "encodes dictionaries with sorted keys" do
+      encoded = described_class.encode({ "b" => 1, "a" => 2 })
+      expect(encoded).to eq("d1:ai2e1:bi1ee")
+    end
 
-  it "should decode integer" do
-    Bencode.decode('i111111e').should == 111111
-    Bencode.decode('i2222e').should == 2222
-    Bencode.decode('ie').should == 0
-  end
-
-  it "should decode list" do
-    Bencode.decode('li33ei66ei99ee').should == [33, 66, 99]
-  end
-
-  it "should decode hash" do
-    Bencode.decode('di35e8:testtest').should == {35 => 'testtest'}
-  end
-
-  it "should decode complex structures" do
-    obj = {35 => [1,2], '3' => 4, '555' => [66, '7777'], 8 => {9 => 10}}
-    Bencode.decode(obj.bencode).should == obj
-  end
-end
-
-describe Bencode do
-  it "should parse torrent files" do
-    Dir["#{Rails.root}/spec/fixtures/*.torrent"].each do |f|
-      lambda {
-        torrent_data = Bencode.decode(File.open(f).read)
-        File.open(f.gsub('.torrent', '.yaml'), 'w') {|ff|
-          ff << torrent_data.to_yaml
-        }
-      }.should_not raise_exception(Exception)
+    it "raises on unsupported types" do
+      expect { described_class.encode(0.22) }.to raise_error(Bencode::EncodeError)
     end
   end
-end
 
-describe Bencode do
-  it "should raise error" do
-    lambda {
-      (0.22).bencode
-    }.should raise_exception(Bencode::Error)
+  describe ".decode" do
+    it "decodes strings" do
+      expect(described_class.decode("5:hello")).to eq("hello")
+      expect(described_class.decode("0:")).to eq("")
+    end
+
+    it "decodes integers" do
+      expect(described_class.decode("i111111e")).to eq(111_111)
+      expect(described_class.decode("ie")).to eq(0)
+    end
+
+    it "decodes lists" do
+      expect(described_class.decode("li33ei66ei99ee")).to eq([33, 66, 99])
+    end
+
+    it "decodes dictionaries" do
+      expect(described_class.decode("di35e8:testtest")).to eq({ "35" => "testtest" })
+    end
+
+    it "decodes complex structures" do
+      object = { "35" => [1, 2], "3" => 4, "555" => [66, "7777"], "8" => { "9" => 10 } }
+      expect(described_class.decode(described_class.encode(object))).to eq(object)
+    end
+
+    it "raises on malformed payloads" do
+      expect { described_class.decode("di35e") }.to raise_error(Bencode::DecodeError)
+    end
+  end
+
+  describe "CLI" do
+    let(:executable) { File.expand_path("../bin/bencode", __dir__) }
+
+    it "decodes from a file" do
+      Tempfile.create("input.bencode") do |file|
+        file.write("5:hello")
+        file.flush
+
+        output = `#{executable} --decode --file #{file.path}`.strip
+        expect(JSON.parse(output)).to eq("hello")
+      end
+    end
+
+    it "encodes JSON from stdin" do
+      json = { greeting: "hi" }.to_json
+      output = IO.popen([executable, "--encode"], "r+") do |io|
+        io.write(json)
+        io.close_write
+        io.read
+      end
+
+      expect(output).to eq("d8:greeting2:hie")
+    end
+
+    it "writes to an output file" do
+      Tempfile.create("input.bencode") do |input|
+        Tempfile.create("output.json") do |output|
+          input.write("i42e")
+          input.flush
+
+          system(executable, "--decode", "--file", input.path, "--output", output.path)
+          expect(JSON.parse(File.read(output.path))).to eq(42)
+        end
+      end
+    end
   end
 end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,0 +1,11 @@
+# frozen_string_literal: true
+
+require "bundler/setup"
+require "bencode"
+require "json"
+
+RSpec.configure do |config|
+  config.expect_with :rspec do |expectations|
+    expectations.syntax = :expect
+  end
+end


### PR DESCRIPTION
## Summary
- refactor the bencode implementation into dedicated encoder/decoder classes with versioning
- add a CLI for encoding/decoding between bencode and JSON along with documentation updates
- introduce gem scaffolding (gemspec, Gemfile, Rakefile) and refreshed specs

## Testing
- bundle install *(fails: unable to fetch gems; rubygems.org returned 403 Forbidden)*
- not run rspec *(dependencies not installed due to bundler fetch failure)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_693032db071c832da2c43958d02785f5)